### PR TITLE
Gareth/feed improvements

### DIFF
--- a/classes/XLite/Module/PureClarity/Personalization/Controller/Admin/PureclarityDashboard.php
+++ b/classes/XLite/Module/PureClarity/Personalization/Controller/Admin/PureclarityDashboard.php
@@ -80,7 +80,7 @@ class PureclarityDashboard extends AAdmin
      */
     public function getXCartVersion() : string
     {
-        return XLite::getVersion();
+        return \XLite::getInstance()->getVersion();
     }
 
     /**

--- a/classes/XLite/Module/PureClarity/Personalization/Core/Delta/Product.php
+++ b/classes/XLite/Module/PureClarity/Personalization/Core/Delta/Product.php
@@ -83,7 +83,7 @@ class Product extends Singleton
             }
             $state->setStateValue('product_delta_running', '');
         } catch (Exception $e) {
-            Logger::logCustom('pureclarity', 'PC Delta ERROR:' . $e->getMessage(), true);
+            Logger::logCustom('pureclarity', 'PC Delta ERROR:' . $e->getMessage(), false);
             $state = State::getInstance();
             $state->setStateValue('product_delta_error', $e->getMessage());
             $state->setStateValue('product_delta_running', '');

--- a/classes/XLite/Module/PureClarity/Personalization/Core/Feeds/Product/Data/Row.php
+++ b/classes/XLite/Module/PureClarity/Personalization/Core/Feeds/Product/Data/Row.php
@@ -243,7 +243,7 @@ class Row extends Singleton implements FeedRowDataInterface
         $currencyCode = $this->getCurrencyCode();
         $this->rowData['Prices'] = [$row->getPrice() . ' ' . $currencyCode];
 
-        if ($row->getSalePriceValue() && $row->getSalePriceValue() !== $row->getPrice()) {
+        if ($row->getParticipateSale() && $row->getSalePriceValue() && $row->getSalePriceValue() !== $row->getPrice()) {
             $this->rowData['SalePrices'] = [
                 $row->getSalePriceValue() . ' ' . $currencyCode
             ];
@@ -295,11 +295,13 @@ class Row extends Singleton implements FeedRowDataInterface
                     $this->rowData['Prices'][] = $variant->getPrice() . ' ' . $currencyCode;
 
 
-                if ($variant->getSalePriceValue() && $variant->getSalePriceValue() !== $variant->getPrice()) {
-                    $this->rowData['SalePrices'] = [
-                        $this->rowData->getSalePriceValue() . ' ' . $currencyCode
-                    ];
-                }
+                    if ($variant->getParticipateSale() &&
+                        $variant->getSalePriceValue() &&
+                        $variant->getSalePriceValue() !== $variant->getPrice()) {
+                        $this->rowData['SalePrices'] = [
+                            $this->rowData->getSalePriceValue() . ' ' . $currencyCode
+                        ];
+                    }
 
                     if ($variant->getProduct()->isWholesalePricesEnabled()) {
                         foreach ($this->getMemberships() as $membership) {

--- a/classes/XLite/Module/PureClarity/Personalization/Core/Feeds/Product/Data/Row.php
+++ b/classes/XLite/Module/PureClarity/Personalization/Core/Feeds/Product/Data/Row.php
@@ -210,14 +210,9 @@ class Row extends Singleton implements FeedRowDataInterface
     protected function getProductImageURL($row) : string
     {
         $imageUrl = '';
-
-        if ($row->getImage()) {
-            list(
-                $usedWidth,
-                $usedHeight,
-                $imageUrl,
-                $retinaResizedURL
-                ) = $row->getImage()->getResizedURL(262, 280);
+        $image = $row->getImage();
+        if ($image) {
+            $imageUrl = $image->getFrontURL();
         } else {
             $url = \XLite::getInstance()->getOptions(['images', 'default_image']);
             if (!Converter::isURL($url)) {

--- a/classes/XLite/Module/PureClarity/Personalization/Core/Feeds/Runner.php
+++ b/classes/XLite/Module/PureClarity/Personalization/Core/Feeds/Runner.php
@@ -9,6 +9,7 @@ namespace XLite\Module\PureClarity\Personalization\Core\Feeds;
 use Exception;
 use PureClarity\Api\Feed\Feed;
 use XLite\Base\Singleton;
+use XLite\Logger;
 use XLite\Module\PureClarity\Personalization\Core\PureClarity;
 use XLite\Module\PureClarity\Personalization\Core\State;
 
@@ -63,11 +64,10 @@ class Runner extends Singleton
                     $feedClass->start();
 
                     foreach ($data as $row) {
-                        $data = $rowDataClass->getRowData($row);
-                        if (!empty($data)) {
-                            $feedClass->append($data);
+                        $rowData = $rowDataClass->getRowData($row);
+                        if (!empty($rowData)) {
+                            $feedClass->append($rowData);
                         }
-
                         $currentRow++;
                         $this->flagProgress($feedType, $currentRow);
                     }
@@ -78,7 +78,8 @@ class Runner extends Singleton
                 $this->flagFeedEnd($feedType);
             }
         } catch (Exception $e) {
-            $this->flagFeedError($feedType, $e->getMessage());
+            Logger::logCustom('pureclarity', 'PC ' . $feedType . ' feed error :' . $e->getMessage(), true);
+            $this->flagFeedError($feedType, 'PCERROR:' . $e->getMessage());
         }
     }
 

--- a/classes/XLite/Module/PureClarity/Personalization/Core/Feeds/Runner.php
+++ b/classes/XLite/Module/PureClarity/Personalization/Core/Feeds/Runner.php
@@ -78,7 +78,7 @@ class Runner extends Singleton
                 $this->flagFeedEnd($feedType);
             }
         } catch (Exception $e) {
-            Logger::logCustom('pureclarity', 'PC ' . $feedType . ' feed error :' . $e->getMessage(), true);
+            Logger::logCustom('pureclarity', 'PC ' . $feedType . ' feed error :' . $e->getMessage(), false);
             $this->flagFeedError($feedType, 'PCERROR:' . $e->getMessage());
         }
     }

--- a/classes/XLite/Module/PureClarity/Personalization/Core/Task/FeedRunner.php
+++ b/classes/XLite/Module/PureClarity/Personalization/Core/Task/FeedRunner.php
@@ -72,10 +72,13 @@ class FeedRunner extends Periodic
         $state = State::getInstance();
         // Run scheduled Feeds
         $feeds = $state->getStateValue('requested_feeds');
-        if (!empty($feeds)) {
+        $running = $state->getStateValue('requested_feeds_running');
+        if (!empty($feeds) && $running !== '1') {
+            $state->setStateValue('requested_feeds_running', '1');
             $feedTypes = json_decode($feeds);
             $this->sendFeeds($feedTypes);
             $state->setStateValue('requested_feeds', '');
+            $state->setStateValue('requested_feeds_running', '');
         }
     }
 

--- a/classes/XLite/Module/PureClarity/Personalization/Core/Task/FeedRunner.php
+++ b/classes/XLite/Module/PureClarity/Personalization/Core/Task/FeedRunner.php
@@ -21,6 +21,9 @@ use XLite\Module\PureClarity\Personalization\Core\State;
  */
 class FeedRunner extends Periodic
 {
+    /** @var string - hour that the feed is due to run on, in date('H') format. */
+    public const FEED_HOUR = '03';
+
     /**
      * Returns the title of this task
      *
@@ -87,17 +90,16 @@ class FeedRunner extends Periodic
             $state = State::getInstance();
             $nightlyFeedRun = $state->getStateValue('nightly_feed_run');
             $hour = date('H');
-            if ($hour === '3' && empty($nightlyFeedRun)) {
-                // it's 3am, time to run the feeds
-                $feedTypes = [
+            if ($hour === self::FEED_HOUR && empty($nightlyFeedRun)) {
+                // set the feed run status early, so if this takes long we don't get multiple instances
+                $state->setStateValue('nightly_feed_run', '1');
+                $this->sendFeeds([
                     Feed::FEED_TYPE_PRODUCT,
                     Feed::FEED_TYPE_CATEGORY,
                     Feed::FEED_TYPE_BRAND,
                     Feed::FEED_TYPE_USER,
-                ];
-                $this->sendFeeds($feedTypes);
-                $state->setStateValue('nightly_feed_run', '1');
-            } elseif ($nightlyFeedRun === '1') {
+                ]);
+            } elseif ($hour !== self::FEED_HOUR && $nightlyFeedRun === '1') {
                 // Reset feed if not 3am, so that when 3am hits, it'll run
                 $state->setStateValue('nightly_feed_run', '');
             }


### PR DESCRIPTION
Various improvements to feed running, delta running and product data gathering

Delta improvements: 

- Added running flag to prevent double running, also added error logging to file to make log checking easier

Feed Runner improvements: 

- Tweaked data loop to prevent data corruption. Added error logging to make error checking easier.
- Fixes to nightly feed to prevent running for the whole feed hour, and preventing duplicate running if it takes longer than usual
- Added flag to requested feed running to prevent double-running if feed is long-running and the cron job tries to run again

Product data fixes:

- Fix to product feed data so that it checks for the presence of the getVariants function before trying to run it (will only be present if the variants module is present)
- Fix to image urls so it uses the getFrontUrl function to return correct image url
- Fix to product data for sale prices to only include sale prices if the product is marked as on sale

Other fixes:

- Changed usage of XLite > GetVersion as it's not a static function and is logging a minor error